### PR TITLE
Fix for boost path when cryptoTools is part of larger project

### DIFF
--- a/cryptoTools/CMakeLists.txt
+++ b/cryptoTools/CMakeLists.txt
@@ -94,7 +94,7 @@ target_link_libraries(cryptoTools ${MIRACL_LIB})
 ## Boost
 ###########################################################################
 
-set(BOOST_ROOT "${CMAKE_HOME_DIRECTORY}/cryptoTools/thirdparty/linux/boost/")
+set(BOOST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty/linux/boost/")
 
 set(Boost_USE_STATIC_LIBS        ON) # only find static libs
 set(Boost_USE_MULTITHREADED      ON)


### PR DESCRIPTION
Follows the same pattern as miracle now. I noticed this as all of a sudden cmake could only find the system boost library (1.58), and not the included 1.59. Apparently it didn't find the local copy and made a fall-back to 1.58. However for systems without boost this will most surely just crash.