### PR TITLE
Do not force Boost to be statically linked to runtime

### DIFF
--- a/cryptoTools/CMakeLists.txt
+++ b/cryptoTools/CMakeLists.txt
@@ -154,7 +154,7 @@ set(BOOST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty/linux/boost/")
 
 set(Boost_USE_STATIC_LIBS        ON) # only find static libs
 set(Boost_USE_MULTITHREADED      ON)
-set(Boost_USE_STATIC_RUNTIME     ON)
+# set(Boost_USE_STATIC_RUNTIME     ON)
 
 find_package(Boost 1.69.0 COMPONENTS system thread)
 


### PR DESCRIPTION
Necessary to be able to use boost as installed by HomeBrew on macOS.