### PR TITLE
Rename loadCA to loadCert

### DIFF
--- a/tests_cryptoTools/BtChannel_Tests.cpp
+++ b/tests_cryptoTools/BtChannel_Tests.cpp
@@ -38,7 +38,7 @@ namespace tests_cryptoTools
             error_code ec;
             ctx.init(TLSContext::Mode::Both, ec);
             if (!ec) ctx.requestClientCert(ec);
-            if (!ec) ctx.loadCA(sample_ca_cert_pem, ec);
+            if (!ec) ctx.loadCert(sample_ca_cert_pem, ec);
             if (!ec) ctx.loadKeyPair(sample_server_cert_pem, sample_server_key_pem, ec);
             if (ec)
                 throw std::runtime_error(ec.message());


### PR DESCRIPTION
There is no member loadCA in WolfsslContext, but there is loadCert which seems sensible here. Without the change the frontend will not compile. After the change all tests run as expected.