### PR TITLE
Fix compilation error when enable boost

### DIFF
--- a/cmake/cryptoToolsDepHelper.cmake
+++ b/cmake/cryptoToolsDepHelper.cmake
@@ -169,6 +169,28 @@ if (ENABLE_SODIUM)
     endif()
 endif (ENABLE_SODIUM)
 
+## Span
+###########################################################################
+
+macro(FIND_SPAN)
+    set(ARGS ${ARGN})
+    if(FETCH_SPAN_LITE)
+        list(APPEND ARGS NO_DEFAULT_PATH PATHS ${OC_THIRDPARTY_HINT})
+    elseif(${NO_SYSTEM_PATH})
+        list(APPEND ARGS NO_CMAKE_SYSTEM_PATH)
+    endif()
+    find_package(span-lite ${ARGS})
+endmacro()
+    
+if (FETCH_SPAN_LITE_IMPL)
+    FIND_SPAN(QUIET)
+    include("${CMAKE_CURRENT_LIST_DIR}/../thirdparty/getSpanLite.cmake")
+endif()
+
+if(ENABLE_SPAN_LITE)
+    FIND_SPAN(REQUIRED)
+endif()
+
 ## coproto
 ###########################################################################
 
@@ -225,28 +247,6 @@ if(ENABLE_COPROTO)
     FIND_COPROTO(REQUIRED)
 endif()
 
-
-## Span
-###########################################################################
-
-macro(FIND_SPAN)
-    set(ARGS ${ARGN})
-    if(FETCH_SPAN_LITE)
-        list(APPEND ARGS NO_DEFAULT_PATH PATHS ${OC_THIRDPARTY_HINT})
-    elseif(${NO_SYSTEM_PATH})
-        list(APPEND ARGS NO_CMAKE_SYSTEM_PATH)
-    endif()
-    find_package(span-lite ${ARGS})
-endmacro()
-    
-if (FETCH_SPAN_LITE_IMPL)
-    FIND_SPAN(QUIET)
-    include("${CMAKE_CURRENT_LIST_DIR}/../thirdparty/getSpanLite.cmake")
-endif()
-
-if(ENABLE_SPAN_LITE)
-    FIND_SPAN(REQUIRED)
-endif()
 ## GMP
 ###########################################################################
 


### PR DESCRIPTION
I found a compilation error when I was compiling cryptoTools with the following commands:

```bash
git clone https://github.com/ladnir/cryptoTools
cd cryptoTools
python build.py --setup --boost --relic
```

The detailed output is 

```bash
CMake Error at cmake/coprotoFindDeps.cmake:25 (find_package):
  By not providing "Findspan-lite.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "span-lite", but CMake did not find one.

  Could not find a package configuration file provided by "span-lite" with
  any of the following names:

    span-liteConfig.cmake
    span-lite-config.cmake

  Add the installation prefix of "span-lite" to CMAKE_PREFIX_PATH or set
  "span-lite_DIR" to a directory containing one of the above files.  If
  "span-lite" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  cmake/coprotoFindDeps.cmake:35 (FIND_SPAN)
  CMakeLists.txt:21 (include)


-- Configuring incomplete, errors occurred!
CMake Error at thirdparty/fetch.cmake:21 (message):
  Configure failed (1).
Call Stack (most recent call first):
  thirdparty/getCoproto.cmake:50 (run)
  cmake/cryptoToolsDepHelper.cmake:222 (include)
  CMakeLists.txt:171 (include)


-- Configuring incomplete, errors occurred!
```

It cannot find span-lite when configuring coproto. The reason is that coproto is configured ahead of span-lite in `cmake/cryptoToolsDepHelper.cmake`. I exchange their position in the file and now the compilation works.
